### PR TITLE
bugfix/accurics_remediation_822098393054292 - Auto Generated Pull Request From Accurics

### DIFF
--- a/Section 5 - Remote State Management/myrepo/kplabs-git/rds.tf
+++ b/Section 5 - Remote State Management/myrepo/kplabs-git/rds.tf
@@ -1,5 +1,5 @@
 resource "aws_db_instance" "default" {
-  allocated_storage    = 5
+  allocated_storage    = 200
   storage_type         = "gp2"
   engine               = "mysql"
   engine_version       = "5.7"
@@ -8,5 +8,5 @@ resource "aws_db_instance" "default" {
   username             = "foo"
   password             = "${file("../rds_pass.txt")}"
   parameter_group_name = "default.mysql5.7"
-  skip_final_snapshot = "true"
+  skip_final_snapshot  = "true"
 }


### PR DESCRIPTION
Automated backups can be enabled using AWS Console or AWS CLI.
 In AWS Console - 
 1. Sign in to the AWS Console and go to the Amazon RDS console.
 2. Select Databases, and then choose the DB instance that you want to modify in the navigation pane.
 3. Select Modify.
 4. For Backup retention period, select the recommended 30 days value.
 5. Select Continue.
 6. Select Apply immediately.
 7. On the confirmation page, select Modify DB instance to save your changes and enable automated backups.
 Using AWS CLI - 
 Use the command : 'modify-db-instance' with the following parameters: 
   a.--db-instance-identifier 
   b. --backup-retention-period 
   c. --apply-immediately 
This will enable automated backups for AWS RDS instances.